### PR TITLE
fix live votes

### DIFF
--- a/voting/live_env.py
+++ b/voting/live_env.py
@@ -23,6 +23,7 @@ class BrowserEnv(LiveEnv):
             logger.error(f"Failed to connect to browser wallet: {e}.")
             return False
         logger.info(f"Connected to browser wallet as {boa.env.eoa}")
+        return True
 
 
 class CustomEnv(LiveEnv):


### PR DESCRIPTION
`BrowserEnv.set()` had a missing `return True` statement after successfully connecting to the browser wallet. The method would implicitly return `None`, which is falsy, causing the check `if not live_env.set():` in `_create_vote()` to evaluate to `True` and return early.

Added `return True` at the end of `BrowserEnv.set()`.