### PR TITLE
fix: ensure context managers clean up on exception

### DIFF
--- a/voting/context.py
+++ b/voting/context.py
@@ -13,8 +13,10 @@ def use_dao(dao: DAOParameters):
     global _dao
     assert not _dao, "DAO is already set"
     _dao = dao
-    yield
-    _dao = None
+    try:
+        yield
+    finally:
+        _dao = None
 
 
 def get_dao() -> DAOParameters:
@@ -26,8 +28,10 @@ def get_dao() -> DAOParameters:
 def use_prepare_calldata(_prepare_calldata):
     prev_prepare_calldata = ABIFunction.prepare_calldata
     ABIFunction.prepare_calldata = _prepare_calldata
-    yield
-    ABIFunction.prepare_calldata = prev_prepare_calldata
+    try:
+        yield
+    finally:
+        ABIFunction.prepare_calldata = prev_prepare_calldata
 
 
 @contextmanager


### PR DESCRIPTION
Context managers using @contextmanager must wrap yield in try/finally to guarantee cleanup runs when exceptions occur. Without this, if code inside 'with vote(...)' raises an exception (e.g., contract reverts), the patched prepare_calldata was never restored, causing an infinite loop in `_prepare_evm_script`.